### PR TITLE
Changes that improve usability with keyboard

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -33,5 +33,6 @@ OBR.onReady(() => {
         anchorElementId: elementId,
       });
     },
+    shortcut: "Shift + C"
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -102,6 +102,7 @@ OBR.onReady(async () => {
   // Add change listener for updating button states
   OBR.scene.items.onChange(updateConditionButtons);
 
+  // Auto focus search bar
   (document.getElementById("search-bar") as HTMLInputElement)?.select();
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -104,6 +104,13 @@ OBR.onReady(async () => {
 
   // Auto focus search bar
   (document.getElementById("search-bar") as HTMLInputElement)?.select();
+
+  // Attach keydown listener to close popover on "Escape" pressed
+  document.addEventListener('keydown', (event) => {
+    if (event.key == "Escape") {
+      OBR.popover.close(getPluginId("condition-markers"));
+    }
+  });
 });
 
 async function loadConditions() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,7 @@ OBR.onReady(async () => {
     appContainer.innerHTML = `
       <div class="conditions">
         <div class="search-area">
-          <input class="condition-filter" placeholder="Filter" type="search"></input>
+          <input class="condition-filter" placeholder="Filter" type="search" id="search-bar"></input>
           <div class="clear-button-div">
             <button class="clear-button" tabindex="-1" type="button" aria-label="Clear" title="Clear">
               <img class="clear-button-img" src="${getImage("close")}"/>
@@ -101,6 +101,8 @@ OBR.onReady(async () => {
 
   // Add change listener for updating button states
   OBR.scene.items.onChange(updateConditionButtons);
+
+  (document.getElementById("search-bar") as HTMLInputElement)?.select();
 });
 
 async function loadConditions() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -111,7 +111,11 @@ OBR.onReady(async () => {
   // Attach keydown listener to close popover on "Escape" pressed
   document.addEventListener('keydown', (event) => {
     if (event.key == "Escape") {
-      OBR.popover.close(getPluginId("condition-markers"));
+      if (document.activeElement?.id === "search-bar") {
+        OBR.popover.close(getPluginId("condition-markers"));
+      } else {
+        focusSearchBar();
+      }
     }
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -65,6 +65,7 @@ OBR.onReady(async () => {
       input.value = "";
       filterConditions(input.value);
       inputClear.style.visibility = "hidden";
+      focusSearchBar();
     });
   }
   
@@ -80,6 +81,7 @@ OBR.onReady(async () => {
           showPage();
         }
       }
+      focusSearchBar();
     });
   }
 
@@ -92,6 +94,7 @@ OBR.onReady(async () => {
           showPage();
         }
       }
+      focusSearchBar();
     });
   }
 
@@ -103,7 +106,7 @@ OBR.onReady(async () => {
   OBR.scene.items.onChange(updateConditionButtons);
 
   // Auto focus search bar
-  (document.getElementById("search-bar") as HTMLInputElement)?.select();
+  focusSearchBar();
 
   // Attach keydown listener to close popover on "Escape" pressed
   document.addEventListener('keydown', (event) => {
@@ -352,4 +355,11 @@ async function handleButtonClick(button: HTMLButtonElement) {
       repositionConditionMarker(item);
     }
   }
+
+  focusSearchBar();
+}
+
+//focus search bar
+function focusSearchBar() {
+  (document.getElementById("search-bar") as HTMLInputElement)?.select();
 }

--- a/src/style.css
+++ b/src/style.css
@@ -29,6 +29,11 @@ body {
   border: 0;
   margin: 0;
   user-select: none;
+  border-radius: 100%;
+}
+
+.condition-button:focus {
+  background: rgb(79, 74, 112);
 }
 
 .condition {


### PR DESCRIPTION
Hi, I made some changes to the extension for personal use but figured I'd shoot them your way in case you want to implement them in the public version. I wanted to navigate around the extension a little faster using my keyboard so that is the objective of these changes.

***Changes***
* Search bar is focussed when the popover loads
* Search bar is focussed after any of the button elements are clicked with the goal of always having it focussed so the user can start typing at any time
* Context menu opens with shortcut "Shift + C"
* Added a highlight to the condition buttons when they are focussed, so the user can easily identify the current focus if they are using tab to cycle though them
* Pressing the escape key closes the popover when the search bar is focussed, and focusses the search bar if it is not focussed

***Demo***
https://github.com/kgbergman/conditionmarkers/assets/77430559/cc5c7987-5adc-45ce-a9b7-e38f529fb3bb